### PR TITLE
Fixed broken space behaviour

### DIFF
--- a/content_script.js
+++ b/content_script.js
@@ -138,7 +138,7 @@ function keyListener(e){
 
 	//Space (when scrolled to the bottom of the window)
 	if(!cmdKey && !e.shiftKey && e.keyCode == 32 && e.srcElement == document.body && destinations.next){
-		if(document.body.scrollHeight - document.body.scrollTop - document.documentElement.clientHeight <= 0){
+		if(document.body.scrollHeight - document.body.scrollTop - document.body.clientHeight <= 1){
 			action = "next";
 		}
 	}

--- a/content_script.js
+++ b/content_script.js
@@ -3,6 +3,7 @@ var destiations = {};
 var targets = {};
 var links = [];
 var timer;
+var prevScrollTop;
 
 //Resets the timer and causes populateDestinations() to be called after a delay
 function resetDestinations(){
@@ -21,6 +22,8 @@ function populateDestinations(){
 		clearTimeout(timer);
 	}
 	timer = null;
+
+        prevScrollTop = -1;
 	
 	//Reset the list of destinations
 	destinations = {
@@ -137,11 +140,15 @@ function keyListener(e){
 	}
 
 	//Space (when scrolled to the bottom of the window)
-	if(!cmdKey && !e.shiftKey && e.keyCode == 32 && e.srcElement == document.body && destinations.next){
-	    if(((document.documentElement && document.documentElement.scrollHeight) || document.body.scrollHeight) 
-	       - ((document.documentElement && document.documentElement.scrollTop) || document.body.scrollTop) - document.body.clientHeight <= 1){
-			action = "next";
-		}
+        //End of scroll area is detected by not changing scrollTop on consecutive space bar presses
+	if(!cmdKey && !e.shiftKey && e.keyCode == 32 && e.srcElement == document.body 
+                   && destinations.next && document.body.scrollTop == prevScrollTop){
+	    action = "next";
+	    prevScrollTop = -1;
+	}
+        else {
+            prevScrollTop = document.body.scrollTop;
+            return;
 	}
 
 	//Shift + Space (when scrolled to the top of the window)

--- a/content_script.js
+++ b/content_script.js
@@ -138,7 +138,8 @@ function keyListener(e){
 
 	//Space (when scrolled to the bottom of the window)
 	if(!cmdKey && !e.shiftKey && e.keyCode == 32 && e.srcElement == document.body && destinations.next){
-		if(document.body.scrollHeight - document.body.scrollTop - document.body.clientHeight <= 1){
+	    if(((document.documentElement && document.documentElement.scrollHeight) || document.body.scrollHeight) 
+	       - ((document.documentElement && document.documentElement.scrollTop) || document.body.scrollTop) - document.body.clientHeight <= 1){
 			action = "next";
 		}
 	}


### PR DESCRIPTION
document.documentElement returned <html> element and lead to incorrect
behaviour when space was pressed (next page was visited directly, before repeated space presses could scroll to the end of longer page).

Also rounding errors prevented detection of scroll to the end of page
sometimes.
